### PR TITLE
Fix singlefile verilog source problem with jt51_singlefile.sh 

### DIFF
--- a/ver/common/basic.f
+++ b/ver/common/basic.f
@@ -19,3 +19,5 @@
 ../../hdl/jt51_noise_lfsr.v
 ../../hdl/jt51_kon.v
 ../../hdl/jt51_mod.v
+../../hdl/jt51_csr_op.v
+../../hdl/jt51_csr_ch.v


### PR DESCRIPTION
Fix singlefile verilog source generated by jt51_singlefile.sh doesn't include some sources.