### PR TITLE
Bugfix: Output wavefile was missing every 64th sample.

### DIFF
--- a/ver/verilator/test.cpp
+++ b/ver/verilator/test.cpp
@@ -333,7 +333,7 @@ int main(int argc, char** argv, char** env) {
                     skip_zeros=false;
                     waves.write( top );
                 }
-                next_sample = sim_time.get_time() + SAMPLING_PERIOD;
+                next_sample += SAMPLING_PERIOD;
             }
             last_sample = top->sample;
             writter.Eval();


### PR DESCRIPTION
This was due to incorrect sampling frequency.
This could be observed by analyzing the waveform in audacity, where the note frequency was too high by about 1.5 %.