### PR TITLE
Fix infinite decay rate to look at upper 4 bits

### DIFF
--- a/hdl/jt51_eg.v
+++ b/hdl/jt51_eg.v
@@ -133,7 +133,7 @@ always @(*) begin : rate_step
         endcase
     end
     // a rate_IV of zero keeps the level still
-    step_V = rate_V[5:1]==5'd0 ? 1'b0 : step_idx[ cnt_V ];
+    step_V = rate_V[5:2]==4'd0 ? 1'b0 : step_idx[ cnt_V ];
 end
 
 


### PR DESCRIPTION
`rate_V` appears to hold the key-scaled attack/decay rate mentioned in Fig 2.11 of the YM2151 Application Manual. Only the top 4 bits need to be 0 for an infinite rate. The design was also considering the top bit of the two key scaling bits.

This appears to have been the cause of subtle mismatches between this design and reference hardware I have on my bench.